### PR TITLE
add sonos-web/ to npm install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ sonos-web can be manually installed as follows assuming npm is installed:
 ```bash
 git clone https://github.com/sonos-web/sonos-web
 
-cd client
+cd sonos-web/client
 npm install
 npm run build
 mv dist ../server/


### PR DESCRIPTION
When trying to directly copy and paste into a terminal, as one might try to do, the command as a whole fails to find the proper directory to successfully execute all the commands

updating "cd client" to "cd sonos-web/client" allows the program to continue as expected